### PR TITLE
modification on video preparation.

### DIFF
--- a/Unity VideoPlayer - Part 1/Assets/StreamVideo.cs
+++ b/Unity VideoPlayer - Part 1/Assets/StreamVideo.cs
@@ -66,14 +66,9 @@ public class StreamVideo : MonoBehaviour {
         videoPlayer.Prepare();
 
         //Wait until video is prepared
-        WaitForSeconds waitTime = new WaitForSeconds(1);
         while (!videoPlayer.isPrepared)
         {
-            Debug.Log("Preparing Video");
-            //Prepare/Wait for 5 sceonds only
-            yield return waitTime;
-            //Break out of the while loop after 5 seconds wait
-            break;
+            yield return null;
         }
 
         Debug.Log("Done Preparing Video");

--- a/Unity VideoPlayer - Play Pause Thumbnail - Part 2/Assets/StreamVideo.cs
+++ b/Unity VideoPlayer - Play Pause Thumbnail - Part 2/Assets/StreamVideo.cs
@@ -64,13 +64,8 @@ public class StreamVideo : MonoBehaviour {
         videoPlayer.Prepare();
 
         //Wait until video is prepared
-        WaitForSeconds waitTime = new WaitForSeconds(1);
         while (!videoPlayer.isPrepared) {
-            Debug.Log("Preparing Video");
-            //Prepare/Wait for 5 sceonds only
-            yield return waitTime;
-            //Break out of the while loop after 5 seconds wait
-            break;
+            yield return null;
         }
 
         Debug.Log("Done Preparing Video");


### PR DESCRIPTION
You should not set time for video preparation. 
Because it may cause unnecessary delay.